### PR TITLE
feat: add log4j2 pattern converter for Clojure ExceptionInfo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,27 @@
           				</execution>
           			</executions>
         		</plugin>
+	    <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.11.0</version>
+              <configuration>
+                 <compilerArgs>
+		   <arg>-XprintProcessorInfo</arg>
+		   <arg>-XprintRounds</arg>
+		 </compilerArgs>
+		 <annotationProcessorPaths>
+                  <path>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                    <version>2.25.1</version>
+                  </path>
+                </annotationProcessorPaths>
+		<annotationProcessors>
+		  <annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</annotationProcessor>
+		</annotationProcessors>
+              </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/main/java/com/rpl/rama/helpers/log4j2/ExceptionInfoConverter.java
+++ b/src/main/java/com/rpl/rama/helpers/log4j2/ExceptionInfoConverter.java
@@ -1,0 +1,228 @@
+package com.rpl.rama.helpers.log4j2;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+import org.apache.logging.log4j.core.impl.ThrowableFormatOptions;
+import org.apache.logging.log4j.core.pattern.ThrowablePatternConverter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Custom Log4j2 PatternConverter that handles Clojure ExceptionInfo specially.
+ *
+ * For clojure.lang.ExceptionInfo, it appends the exception's data map after the message.
+ * For all other exceptions, it behaves like the default throwable converter.
+ *
+ * Usage in log4j2.xml pattern:
+ *   %exInfo        - full stack trace (default)
+ *   %exInfo{short} - first line only with data
+ *   %exInfo{n}     - first n lines of stack trace
+ *   %exInfo{none}  - suppress output
+ */
+@Plugin(name = "ExceptionInfoConverter", category = PatternConverter.CATEGORY)
+@ConverterKeys({"exInfo", "exceptionInfo"})
+public class ExceptionInfoConverter extends LogEventPatternConverter {
+
+    private static final String EXCEPTION_INFO_CLASS = "clojure.lang.ExceptionInfo";
+
+    private final String[] options;
+    private final boolean shortFormat;
+    private final boolean none;
+    private final int lines;
+
+    private ExceptionInfoConverter(String[] options) {
+        super("ExceptionInfo", "exceptionInfo");
+        this.options = options;
+
+        if (options == null || options.length == 0) {
+            this.shortFormat = false;
+            this.none = false;
+            this.lines = Integer.MAX_VALUE;
+        } else {
+            String opt = options[0].toLowerCase();
+            this.none = opt.equals("none") || opt.equals("0");
+            this.shortFormat = opt.equals("short");
+
+            int parsedLines = Integer.MAX_VALUE;
+            if (!none && !shortFormat) {
+                try {
+                    parsedLines = Integer.parseInt(opt);
+                } catch (NumberFormatException e) {
+                    // ignore, use default
+                }
+            }
+            this.lines = parsedLines;
+        }
+    }
+
+    public static ExceptionInfoConverter newInstance(String[] options) {
+        return new ExceptionInfoConverter(options);
+    }
+
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        Throwable throwable = event.getThrown();
+        if (throwable == null) {
+            return;
+        }
+
+        if (none) {
+            return;
+        }
+
+        if (isExceptionInfo(throwable)) {
+            formatExceptionInfo(throwable, toAppendTo);
+        } else {
+            formatDefault(throwable, toAppendTo);
+        }
+    }
+
+    private boolean isExceptionInfo(Throwable throwable) {
+        // Check by class name to avoid hard dependency on Clojure
+        Class<?> clazz = throwable.getClass();
+        while (clazz != null) {
+            if (EXCEPTION_INFO_CLASS.equals(clazz.getName())) {
+                return true;
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return false;
+    }
+
+    private void formatExceptionInfo(Throwable throwable, StringBuilder toAppendTo) {
+        String className = throwable.getClass().getName();
+        String message = throwable.getMessage();
+        String data = getExceptionInfoData(throwable);
+
+        if (shortFormat) {
+            // Short format: ClassName: message {data}
+            toAppendTo.append(className);
+            if (message != null) {
+                toAppendTo.append(": ").append(message);
+            }
+            if (data != null) {
+                toAppendTo.append(" ").append(data);
+            }
+        } else {
+            // Full format: first line with data, then stack trace
+            toAppendTo.append(className);
+            if (message != null) {
+                toAppendTo.append(": ").append(message);
+            }
+            if (data != null) {
+                toAppendTo.append(" ").append(data);
+            }
+            toAppendTo.append(System.lineSeparator());
+            appendStackTrace(throwable, toAppendTo);
+        }
+    }
+
+    private String getExceptionInfoData(Throwable throwable) {
+        try {
+            // Use reflection to call getData() on ExceptionInfo
+            // This avoids a compile-time dependency on Clojure
+            java.lang.reflect.Method getDataMethod = throwable.getClass().getMethod("getData");
+            Object data = getDataMethod.invoke(throwable);
+            if (data != null) {
+                return data.toString();
+            }
+        } catch (Exception e) {
+            // If reflection fails, return null
+        }
+        return null;
+    }
+
+    private void formatDefault(Throwable throwable, StringBuilder toAppendTo) {
+        if (shortFormat) {
+            // Short format: just the first line
+            toAppendTo.append(throwable.getClass().getName());
+            if (throwable.getMessage() != null) {
+                toAppendTo.append(": ").append(throwable.getMessage());
+            }
+        } else {
+            // Full stack trace
+            toAppendTo.append(throwable.getClass().getName());
+            if (throwable.getMessage() != null) {
+                toAppendTo.append(": ").append(throwable.getMessage());
+            }
+            toAppendTo.append(System.lineSeparator());
+            appendStackTrace(throwable, toAppendTo);
+        }
+    }
+
+    private void appendStackTrace(Throwable throwable, StringBuilder toAppendTo) {
+        StackTraceElement[] stackTrace = throwable.getStackTrace();
+        int linesToPrint = Math.min(stackTrace.length, lines);
+
+        for (int i = 0; i < linesToPrint; i++) {
+            toAppendTo.append("\tat ").append(stackTrace[i]).append(System.lineSeparator());
+        }
+
+        if (linesToPrint < stackTrace.length) {
+            toAppendTo.append("\t... ").append(stackTrace.length - linesToPrint).append(" more").append(System.lineSeparator());
+        }
+
+        // Handle cause chain
+        Throwable cause = throwable.getCause();
+        if (cause != null && lines > linesToPrint) {
+            appendCause(cause, toAppendTo, stackTrace, lines - linesToPrint);
+        }
+    }
+
+    private void appendCause(Throwable cause, StringBuilder toAppendTo,
+                            StackTraceElement[] enclosingTrace, int remainingLines) {
+        if (remainingLines <= 0) {
+            return;
+        }
+
+        toAppendTo.append("Caused by: ");
+
+        // Check if cause is also ExceptionInfo
+        if (isExceptionInfo(cause)) {
+            toAppendTo.append(cause.getClass().getName());
+            if (cause.getMessage() != null) {
+                toAppendTo.append(": ").append(cause.getMessage());
+            }
+            String data = getExceptionInfoData(cause);
+            if (data != null) {
+                toAppendTo.append(" ").append(data);
+            }
+        } else {
+            toAppendTo.append(cause.getClass().getName());
+            if (cause.getMessage() != null) {
+                toAppendTo.append(": ").append(cause.getMessage());
+            }
+        }
+        toAppendTo.append(System.lineSeparator());
+
+        StackTraceElement[] causeTrace = cause.getStackTrace();
+
+        // Find common frames with enclosing exception
+        int m = causeTrace.length - 1;
+        int n = enclosingTrace.length - 1;
+        while (m >= 0 && n >= 0 && causeTrace[m].equals(enclosingTrace[n])) {
+            m--;
+            n--;
+        }
+        int commonFrames = causeTrace.length - 1 - m;
+        int framesToPrint = Math.min(m + 1, remainingLines);
+
+        for (int i = 0; i < framesToPrint; i++) {
+            toAppendTo.append("\tat ").append(causeTrace[i]).append(System.lineSeparator());
+        }
+
+        if (commonFrames > 0) {
+            toAppendTo.append("\t... ").append(commonFrames).append(" common frames omitted").append(System.lineSeparator());
+        }
+
+        // Recurse for nested causes
+        Throwable nestedCause = cause.getCause();
+        if (nestedCause != null) {
+            appendCause(nestedCause, toAppendTo, causeTrace, remainingLines - framesToPrint);
+        }
+    }
+}

--- a/src/test/java/com/rpl/rama/helpers/log4j2/ExceptionInfoConverterTest.java
+++ b/src/test/java/com/rpl/rama/helpers/log4j2/ExceptionInfoConverterTest.java
@@ -1,0 +1,257 @@
+package com.rpl.rama.helpers.log4j2;
+
+import clojure.lang.ExceptionInfo;
+import clojure.lang.IPersistentMap;
+import clojure.lang.Keyword;
+import clojure.lang.PersistentHashMap;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ExceptionInfoConverter")
+public class ExceptionInfoConverterTest {
+
+  private static final String LINE_SEP = System.lineSeparator();
+
+  private LogEvent createLogEvent(Throwable thrown) {
+    return Log4jLogEvent.newBuilder()
+      .setLevel(Level.ERROR)
+      .setMessage(new SimpleMessage("test"))
+      .setThrown(thrown)
+      .build();
+  }
+
+  private ExceptionInfo createExceptionInfo(String msg, Object... kvs) {
+    IPersistentMap data = PersistentHashMap.EMPTY;
+    for (int i = 0; i < kvs.length; i += 2) {
+      data = data.assoc(kvs[i], kvs[i + 1]);
+    }
+    return new ExceptionInfo(msg, data);
+  }
+
+  private ExceptionInfo createExceptionInfo(String msg, Throwable cause, Object... kvs) {
+    IPersistentMap data = PersistentHashMap.EMPTY;
+    for (int i = 0; i < kvs.length; i += 2) {
+      data = data.assoc(kvs[i], kvs[i + 1]);
+    }
+    return new ExceptionInfo(msg, data, cause);
+  }
+
+  @Nested
+  @DisplayName("with no options (full format)")
+  class FullFormat {
+
+    @Test
+    @DisplayName("formats ExceptionInfo with data")
+    void formatsExceptionInfoWithData() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      ExceptionInfo ex = createExceptionInfo("oops", Keyword.intern("code"), 42);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+      String result = sb.toString();
+
+      assertTrue(result.startsWith("clojure.lang.ExceptionInfo: oops {:code 42}"),
+        "output: " + result);
+      assertTrue(result.contains("\tat "), "output: " + result);
+    }
+
+    @Test
+    @DisplayName("formats regular exception without data")
+    void formatsRegularException() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      RuntimeException ex = new RuntimeException("boom");
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+      String result = sb.toString();
+
+      assertTrue(result.startsWith("java.lang.RuntimeException: boom"),
+        "output: " + result);
+      assertTrue(result.contains("\tat "), "output: " + result);
+    }
+
+    @Test
+    @DisplayName("outputs nothing when no exception")
+    void outputsNothingWhenNoException() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      LogEvent event = Log4jLogEvent.newBuilder()
+        .setLevel(Level.ERROR)
+        .setMessage(new SimpleMessage("test"))
+        .build();
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(event, sb);
+
+      assertEquals("", sb.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("with short option")
+  class ShortFormat {
+
+    @Test
+    @DisplayName("formats ExceptionInfo on single line with data")
+    void formatsExceptionInfoOnSingleLine() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"short"});
+      ExceptionInfo ex = createExceptionInfo("oops", Keyword.intern("x"), 1);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+      String result = sb.toString();
+
+      assertEquals("clojure.lang.ExceptionInfo: oops {:x 1}", result);
+    }
+
+    @Test
+    @DisplayName("formats regular exception on single line")
+    void formatsRegularExceptionOnSingleLine() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"short"});
+      RuntimeException ex = new RuntimeException("boom");
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+      String result = sb.toString();
+
+      assertEquals("java.lang.RuntimeException: boom", result);
+    }
+  }
+
+  @Nested
+  @DisplayName("with none option")
+  class NoneFormat {
+
+    @Test
+    @DisplayName("outputs nothing")
+    void outputsNothing() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"none"});
+      ExceptionInfo ex = createExceptionInfo("oops", Keyword.intern("x"), 1);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+
+      assertEquals("", sb.toString());
+    }
+
+    @Test
+    @DisplayName("outputs nothing with 0 option")
+    void outputsNothingWithZero() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"0"});
+      ExceptionInfo ex = createExceptionInfo("oops", Keyword.intern("x"), 1);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+
+      assertEquals("", sb.toString());
+    }
+  }
+
+  @Nested
+  @DisplayName("with line limit option")
+  class LineLimitFormat {
+
+    @Test
+    @DisplayName("limits stack trace lines")
+    void limitsStackTraceLines() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"2"});
+      ExceptionInfo ex = createExceptionInfo("oops", Keyword.intern("x"), 1);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(ex), sb);
+      String result = sb.toString();
+
+      String[] lines = result.split(LINE_SEP);
+      // First line is the exception, then 2 stack frames, then "... N more"
+      assertTrue(lines.length >= 3, "lines: " + lines.length);
+      assertTrue(lines[0].contains("ExceptionInfo: oops {:x 1}"),
+        "first line: " + lines[0]);
+      assertTrue(lines[1].startsWith("\tat "), "line 1: " + lines[1]);
+      assertTrue(lines[2].startsWith("\tat "), "line 2: " + lines[2]);
+    }
+  }
+
+  @Nested
+  @DisplayName("with nested causes")
+  class NestedCauses {
+
+    @Test
+    @DisplayName("includes cause chain with data")
+    void includesCauseChainWithData() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"short"});
+      ExceptionInfo inner = createExceptionInfo("inner", Keyword.intern("a"), 1);
+      ExceptionInfo outer = createExceptionInfo("outer", inner, Keyword.intern("b"), 2);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(outer), sb);
+      String result = sb.toString();
+
+      // Short format only shows outer exception
+      assertEquals("clojure.lang.ExceptionInfo: outer {:b 2}", result);
+    }
+
+    @Test
+    @DisplayName("shows nested ExceptionInfo data in full format")
+    void showsNestedDataInFullFormat() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      ExceptionInfo inner = createExceptionInfo("inner", Keyword.intern("a"), 1);
+      ExceptionInfo outer = createExceptionInfo("outer", inner, Keyword.intern("b"), 2);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(outer), sb);
+      String result = sb.toString();
+
+      assertTrue(result.contains("outer {:b 2}"), "output: " + result);
+      assertTrue(result.contains("Caused by: clojure.lang.ExceptionInfo: inner {:a 1}"),
+        "output: " + result);
+    }
+
+    @Test
+    @DisplayName("shows regular cause without data")
+    void showsRegularCauseWithoutData() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      RuntimeException inner = new RuntimeException("root cause");
+      ExceptionInfo outer = createExceptionInfo("wrapper", inner, Keyword.intern("x"), 1);
+      StringBuilder sb = new StringBuilder();
+
+      converter.format(createLogEvent(outer), sb);
+      String result = sb.toString();
+
+      assertTrue(result.contains("wrapper {:x 1}"), "output: " + result);
+      assertTrue(result.contains("Caused by: java.lang.RuntimeException: root cause"),
+        "output: " + result);
+    }
+  }
+
+  @Nested
+  @DisplayName("newInstance factory")
+  class Factory {
+
+    @Test
+    @DisplayName("creates converter with null options")
+    void createsWithNullOptions() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(null);
+      assertNotNull(converter);
+    }
+
+    @Test
+    @DisplayName("creates converter with empty options")
+    void createsWithEmptyOptions() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{});
+      assertNotNull(converter);
+    }
+
+    @Test
+    @DisplayName("creates converter with valid options")
+    void createsWithValidOptions() {
+      ExceptionInfoConverter converter = ExceptionInfoConverter.newInstance(new String[]{"short"});
+      assertNotNull(converter);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ExceptionInfoConverter` that displays `ex-data` from `clojure.lang.ExceptionInfo` in log4j2 stack traces
- Supports format options: `%exInfo` (full), `%exInfo{short}`, `%exInfo{n}`, `%exInfo{none}`
- Uses reflection to avoid compile-time dependency on Clojure

## Test plan
- [ ] Verify converter works with ExceptionInfo exceptions
- [ ] Test format options (short, lines, none)
- [ ] Test with nested ExceptionInfo causes